### PR TITLE
When validating PageSize & PageRegion options, treat 'Custom.WIDTHxHEIGHT' as just 'Custom'.

### DIFF
--- a/lib/cupsffi/printer.rb
+++ b/lib/cupsffi/printer.rb
@@ -153,7 +153,9 @@ class CupsPrinter
     options.each do |key,value|
       raise "Invalid option #{key} for printer #{@name}" if ppd_options[key].nil?
       choices = ppd_options[key][:choices].map{|c| c[:choice]}
-      raise "Invalid value #{value} for option #{key}" unless choices.include?(value)
+      # Treat 'Custom.WIDTHxHEIGHT' as just 'Custom'
+      base_value = (value =~ /^Custom\./ && %w{PageRegion PageSize}.include?(key)) ? 'Custom' : value
+      raise "Invalid value #{value} for option #{key}" unless choices.include?(base_value)
     end
   end
 end


### PR DESCRIPTION
I found that using custom page sizes (eg, 'Custom.17x12in'), CupsFFI would complain about the PPD option value because it wasn't a known choice. In this case, it's 'Custom' that needs to be validated, so I modified the code to create a 'base' value for the relevant options.
