### PR TITLE
Support for libraries in /usr/lib/i386-linux-gnu/

### DIFF
--- a/lib/cupsffi/lib.rb
+++ b/lib/cupsffi/lib.rb
@@ -28,7 +28,7 @@ module CupsFFI
   paths =
     Array(
       ENV['CUPS_LIB'] ||
-      Dir['/{opt,usr}/{,local/}lib{,64}/{,x86_64-linux-gnu/}libcups.{dylib,so*}']
+      Dir['/{opt,usr}/{,local/}lib{,64}/{,x86_64-linux-gnu/,i386-linux-gnu/}libcups.{dylib,so*}']
       )
   raise LoadError, "Didn't find libcups on your system." if paths.empty?
   begin


### PR DESCRIPTION
I've added an additional check if the Path regexp returns an empty array.

Support for libraries in /usr/lib/i386-linux-gnu/ as per some modern Debian/Ubuntu setups is added, too.
