### PR TITLE
Use library path logic built into FFI.

### DIFF
--- a/lib/cupsffi/lib.rb
+++ b/lib/cupsffi/lib.rb
@@ -25,14 +25,12 @@ require 'ffi'
 module CupsFFI
   extend FFI::Library
 
-  paths =
-    Array(
-      ENV['CUPS_LIB'] ||
-      Dir['/{opt,usr}/{,local/}lib{,64}/{,x86_64-linux-gnu/,i386-linux-gnu/}libcups.{dylib,so*}']
-      )
-  raise LoadError, "Didn't find libcups on your system." if paths.empty?
   begin
-    ffi_lib(*paths)
+    if ENV['CUPS_LIB']
+      ffi_lib(ENV['CUPS_LIB'])
+    else
+      ffi_lib('cups')
+    end
   rescue LoadError => le
     raise LoadError, "Didn't find libcups on your system."
   end


### PR DESCRIPTION
The hardcoded library path lookup needed some fixing before. And it still
fails on a Ubuntu multiarch setup with both i368 and amd64 libcups packages.

This reverts the library path lookup introduced in #3835be7a3e while 
maintaining the possibility providing a CUPS_LIB using the environment.
