### PR TITLE
remove duplicate dependency in gemspec

### DIFF
--- a/cupsffi.gemspec
+++ b/cupsffi.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{FFI wrapper around libcups}
   s.description = %q{Simple wrapper around libcups to give CUPS printing capabilities to Ruby apps.}
 
-  s.add_development_dependency "ffi"
   s.add_runtime_dependency "ffi"
 
   s.rubyforge_project = "cupsffi"


### PR DESCRIPTION
This fixes the warning message:

```
cupsffi at ~/.gem/ruby/2.1.2/bundler/gems/cupsffi-5930b0fb8f44 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on ffi (>= 0), (>= 0) use:
    add_runtime_dependency 'ffi', '>= 0', '>= 0'
```

Thanks
K
