### PR TITLE
Support landscape option

### DIFF
--- a/lib/cupsffi/printer.rb
+++ b/lib/cupsffi/printer.rb
@@ -229,7 +229,7 @@ class CupsPrinter
     options.each do |key,value|
       key_string = key.to_s
       # Accept common CUPS options
-      next if ['copies'].include?(key_string)
+      next if ['copies', 'landscape'].include?(key_string)
 
       raise "Invalid option #{key} for printer #{@name}" if ppd_options[key_string].nil?
       choices = ppd_options[key_string][:choices].map{|c| c[:choice]}


### PR DESCRIPTION
This allows the standard option 'landscape' to be passed. To use it:

```ruby
job = printer.print_data('hello world', 'text/plain', {'landscape' => "yes", 'InputSlot' => 'main', 'PageSize' => 'Env10'})
```