### PR TITLE
Allow printing binary data that contains nulls

### DIFF
--- a/lib/cupsffi/lib.rb
+++ b/lib/cupsffi/lib.rb
@@ -245,7 +245,7 @@ module CupsFFI
   #  - length of data
   # Returns
   #  - HttpStatus
-  attach_function 'cupsWriteRequestData', [:pointer, :string, :size_t], HttpStatus
+  attach_function 'cupsWriteRequestData', [:pointer, :pointer, :size_t], HttpStatus
 
   # Parameters
   #  - pointer to http connection to server or CUPS_HTTP_DEFAULT

--- a/lib/cupsffi/printer.rb
+++ b/lib/cupsffi/printer.rb
@@ -172,7 +172,7 @@ class CupsPrinter
     http_status = CupsFFI::cupsStartDocument(@connection, @name,
                                              job_id, 'my doc', mime_type, 1)
 
-    http_status = CupsFFI::cupsWriteRequestData(@connection, data_pointer, data.length)
+    http_status = CupsFFI::cupsWriteRequestData(@connection, data_pointer, data.bytesize)
 
     ipp_status = CupsFFI::cupsFinishDocument(@connection, @name)
 

--- a/lib/cupsffi/printer.rb
+++ b/lib/cupsffi/printer.rb
@@ -165,12 +165,18 @@ class CupsPrinter
       raise last_error
     end
 
+    # Copy the data into a char pointer to allow null bytes
+    data_pointer = FFI::MemoryPointer.new(:char, data.bytesize)
+    data_pointer.put_bytes(0, data)
+
     http_status = CupsFFI::cupsStartDocument(@connection, @name,
                                              job_id, 'my doc', mime_type, 1)
 
-    http_status = CupsFFI::cupsWriteRequestData(@connection, data, data.length)
+    http_status = CupsFFI::cupsWriteRequestData(@connection, data_pointer, data.length)
 
     ipp_status = CupsFFI::cupsFinishDocument(@connection, @name)
+
+    data_pointer.free
 
     unless ipp_status == :ipp_ok
       CupsFFI::cupsFreeOptions(num_options, options_pointer) unless options_pointer.nil?


### PR DESCRIPTION
This should fix #11

When trying to send a string through FFI that contains a NULL byte, an
error would occur: `ArgumentError: string contains null byte`

This sends the raw data as a char pointer instead.

