### PR TITLE
Allow to pass default CUPS `collate` param

### DIFF
--- a/lib/cupsffi/printer.rb
+++ b/lib/cupsffi/printer.rb
@@ -244,7 +244,7 @@ class CupsPrinter
     options.each do |key,value|
       key_string = key.to_s
       # Accept common CUPS options
-      next if ['copies', 'landscape'].include?(key_string)
+      next if %w[collate copies landscape].include?(key_string)
 
       raise "Invalid option #{key} for printer #{@name}" if ppd_options[key_string].nil?
       choices = ppd_options[key_string][:choices].map{|c| c[:choice]}


### PR DESCRIPTION
Passing just `copies` param isn't sufficient now. You have to also pass `collate: true` to allow collating.

See this docs: https://www.cups.org/doc/options.html

> Copies are normally not collated for you. Use the -o collate=true option to get collated copies:
> `lp -n num-copies -o collate=true filename`
> `lpr -#num-copies -o collate=true filename`